### PR TITLE
v0.2.1: fix registerCommand issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-extension-telemetry-wrapper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A module to auto send telemetry for each registered command, using vscode-extension-telemetry.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/TelemetryWrapper.ts
+++ b/src/TelemetryWrapper.ts
@@ -51,8 +51,8 @@ export module TelemetryWrapper {
                         fatal(error, ExitCode.GENERAL_ERROR);
                         throw error;
                     } finally {
-                        endSession(session);
                         resolve();
+                        endSession(session);
                     }
                 });
             });

--- a/src/TelemetryWrapper.ts
+++ b/src/TelemetryWrapper.ts
@@ -37,7 +37,7 @@ export module TelemetryWrapper {
 
     export function registerCommand(command: string, callback: (...args: any[]) => any): vscode.Disposable {
         return vscode.commands.registerCommand(command, async (param: any[]) => {
-            await new Promise<void>(resolve => {
+            await new Promise<void>((resolve, reject) => {
                 sessionNamespace.run(async () => {
                     const session: Session = startSession(command);
                     sessionNamespace.set<Session>(SESSION_KEY, session);
@@ -47,11 +47,11 @@ export module TelemetryWrapper {
                     });
                     try {
                         await callback(param);
+                        resolve();
                     } catch (error) {
                         fatal(error, ExitCode.GENERAL_ERROR);
-                        throw error;
+                        reject(error);
                     } finally {
-                        resolve();
                         endSession(session);
                     }
                 });


### PR DESCRIPTION
Previously if we execute 
```
await vscode.commands.executeCommand("testcommand");
```
the statement ends immediately. 

Ref: [Namespace.prototype.run](https://github.com/othiym23/node-continuation-local-storage/blob/master/context.js#L44)

Now it's wrapped within a promise.