### PR TITLE
0.7.1: upgrade upstream lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-extension-telemetry-wrapper",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -359,9 +359,9 @@
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz",
-      "integrity": "sha512-qIocRYU5TrGUkBlDDxaziAK1+squ8Yf2Ls4HldL3xxb/jzmWO2Enux7CvevNKYmF2kDXZ9HiRqwjPsjk8L+i2Q=="
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
+      "integrity": "sha512-SZ1zMfFiEabf4Qx0Og9V1gMsRoqz3O+5ENkVcNOfI+SMJ3QhQsdEoKX99r0zvreagXot2parPxmrwwUM/ja8ug=="
     },
     "diff": {
       "version": "3.5.0",
@@ -1112,9 +1112,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "vscode-extension-telemetry": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.3.tgz",
-      "integrity": "sha512-2P4/TrxwMRQJPpcsSpreI7JVftmy+kbatONGVY65x4fJfbaHTBTm6jNgkG0Xifv6Th1o25KvaVZUTjN7VWlxBA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.4.tgz",
+      "integrity": "sha512-9U2pUZ/YwZBfA8CkBrHwMxjnq9Ab+ng8daJWJzEQ6CAxlZyRhmck23bx2lqqpEwGWJCiuceQy4k0Me6llEB4zw==",
       "requires": {
         "applicationinsights": "1.7.4"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-extension-telemetry-wrapper",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A module to auto send telemetry for each registered command, using vscode-extension-telemetry.",
   "main": "./lib/src/index.js",
   "activationEvents": [],
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "uuid": "^3.4.0",
-    "vscode-extension-telemetry": "^0.1.3"
+    "vscode-extension-telemetry": "^0.1.4"
   },
   "devDependencies": {
     "@types/glob": "^7.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,12 +62,8 @@ export function initialize(extensionId: string, version: string, aiKey: string, 
     }
 
     if (aiKey) {
-        reporter = new TelemetryReporter(extensionId, version, aiKey);
-    }
-
-    if (options && options.firstParty) {
-        // @ts-ignore
-        reporter.firstParty = options.firstParty;
+        const firstParty: boolean | undefined = options && options.firstParty;
+        reporter = new TelemetryReporter(extensionId, version, aiKey, firstParty);
     }
 
     isDebug = !!(options && options.debug);


### PR DESCRIPTION
Upstream lib has exposed the `firstParty` property. See https://github.com/microsoft/vscode-extension-telemetry/commit/2fd787af0f317712cf982dfa5e00d38b5ef12f37#diff-90dddd74ec13ca1b38d1ae386ebc56f6R28-R30