### PR TITLE
ci: fix uuid vulnerable issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,20 @@
 {
   "name": "vscode-extension-telemetry-wrapper",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-extension-telemetry-wrapper",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
-        "@vscode/extension-telemetry": "^1.2.0",
-        "uuid": "^8.3.2"
+        "@vscode/extension-telemetry": "^1.2.0"
       },
       "devDependencies": {
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.1",
         "@types/node": "^20.8.9",
-        "@types/uuid": "^8.3.4",
         "@types/vscode": "1.75.0",
         "@vscode/test-electron": "^2.4.0",
         "glob": "^7.2.3",
@@ -205,12 +203,6 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-      "dev": true
     },
     "node_modules/@types/vscode": {
       "version": "1.75.0",
@@ -1845,14 +1837,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2153,12 +2137,6 @@
       "requires": {
         "undici-types": "~5.26.4"
       }
-    },
-    "@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-      "dev": true
     },
     "@types/vscode": {
       "version": "1.75.0",
@@ -3345,11 +3323,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-extension-telemetry-wrapper",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A module to auto send telemetry for each registered command in unified format, using @vscode/extension-telemetry.",
   "main": "./lib/src/index.js",
   "activationEvents": [],
@@ -18,14 +18,12 @@
     "url": "https://github.com/Eskibear/vscode-extension-telemetry-wrapper.git"
   },
   "dependencies": {
-    "@vscode/extension-telemetry": "^1.2.0",
-    "uuid": "^8.3.2"
+    "@vscode/extension-telemetry": "^1.2.0"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.1",
     "@types/node": "^20.8.9",
-    "@types/uuid": "^8.3.4",
     "@types/vscode": "1.75.0",
     "glob": "^7.2.3",
     "mocha": "^9.2.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import * as uuid from "uuid";
+import * as crypto from "crypto";
 import * as vscode from "vscode";
 import { TelemetryReporter, ReplacementOption } from "@vscode/extension-telemetry";
 import {
@@ -309,10 +309,10 @@ export function instrumentOperationStep(
 }
 
 /**
- * Create a UUID string using uuid.v4().
+ * Create a UUID string.
  */
 export function createUuid(): string {
-    return uuid.v4();
+    return crypto.randomUUID();
 }
 
 /**


### PR DESCRIPTION
https://github.com/microsoft/vscode-java-dependency/security/dependabot/77

vscode-extension-telemetry-wrapper@0.15.0 requires uuid@^8.3.2

没有直接升 uuid@14，而是移除了 uuid 依赖，改用 Node 内置 crypto.randomUUID()。