### PR TITLE
Bump telemetry wrapper to 0.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "npm:@microsoft/applicationinsights-core-js@^3.4.1",
+        "@microsoft/applicationinsights-common": "^3.4.1",
         "@vscode/extension-telemetry": "^1.2.0"
       },
       "devDependencies": {
@@ -109,7 +109,21 @@
       }
     },
     "node_modules/@microsoft/applicationinsights-common": {
-      "name": "@microsoft/applicationinsights-core-js",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
+      "integrity": "sha512-CTbD0g/68tiv2yCItsodDQBYxyHdfQkG7VhvVU8OHenukpl/7W4wEuxZuOntqhv5m9Nx/DFncbz+T83nvYTG3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common/node_modules/@microsoft/applicationinsights-core-js": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
       "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
@@ -2088,14 +2102,27 @@
       }
     },
     "@microsoft/applicationinsights-common": {
-      "version": "npm:@microsoft/applicationinsights-core-js@3.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
-      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
+      "integrity": "sha512-CTbD0g/68tiv2yCItsodDQBYxyHdfQkG7VhvVU8OHenukpl/7W4wEuxZuOntqhv5m9Nx/DFncbz+T83nvYTG3g==",
       "requires": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
         "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+          "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
+          "requires": {
+            "@microsoft/applicationinsights-shims": "3.0.1",
+            "@microsoft/dynamicproto-js": "^2.0.3",
+            "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+            "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+          }
+        }
       }
     },
     "@microsoft/applicationinsights-core-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "^3.4.1",
+        "@microsoft/applicationinsights-common": "npm:@microsoft/applicationinsights-core-js@^3.4.1",
         "@vscode/extension-telemetry": "^1.2.0"
       },
       "devDependencies": {
@@ -109,21 +109,7 @@
       }
     },
     "node_modules/@microsoft/applicationinsights-common": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
-      "integrity": "sha512-CTbD0g/68tiv2yCItsodDQBYxyHdfQkG7VhvVU8OHenukpl/7W4wEuxZuOntqhv5m9Nx/DFncbz+T83nvYTG3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.4.1",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-common/node_modules/@microsoft/applicationinsights-core-js": {
+      "name": "@microsoft/applicationinsights-core-js",
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
       "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
@@ -2102,27 +2088,14 @@
       }
     },
     "@microsoft/applicationinsights-common": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
-      "integrity": "sha512-CTbD0g/68tiv2yCItsodDQBYxyHdfQkG7VhvVU8OHenukpl/7W4wEuxZuOntqhv5m9Nx/DFncbz+T83nvYTG3g==",
+      "version": "npm:@microsoft/applicationinsights-core-js@3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
       "requires": {
-        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
         "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
-      },
-      "dependencies": {
-        "@microsoft/applicationinsights-core-js": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
-          "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
-          "requires": {
-            "@microsoft/applicationinsights-shims": "3.0.1",
-            "@microsoft/dynamicproto-js": "^2.0.3",
-            "@nevware21/ts-async": ">= 0.5.5 < 2.x",
-            "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
-          }
-        }
       }
     },
     "@microsoft/applicationinsights-core-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "vscode-extension-telemetry-wrapper",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-extension-telemetry-wrapper",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
+        "@microsoft/applicationinsights-common": "^3.4.1",
         "@vscode/extension-telemetry": "^1.2.0"
       },
       "devDependencies": {
@@ -92,7 +93,7 @@
         "tslib": ">= 1.0.0"
       }
     },
-    "node_modules/@microsoft/applicationinsights-common": {
+    "node_modules/@microsoft/applicationinsights-channel-js/node_modules/@microsoft/applicationinsights-common": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.10.tgz",
       "integrity": "sha512-RVIenPIvNgZCbjJdALvLM4rNHgAFuHI7faFzHCgnI6S2WCUNGHeXlQTs9EUUrL+n2TPp9/cd0KKMILU5VVyYiA==",
@@ -102,6 +103,36 @@
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
+      "integrity": "sha512-CTbD0g/68tiv2yCItsodDQBYxyHdfQkG7VhvVU8OHenukpl/7W4wEuxZuOntqhv5m9Nx/DFncbz+T83nvYTG3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common/node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       },
       "peerDependencies": {
         "tslib": ">= 1.0.0"
@@ -149,6 +180,21 @@
         "tslib": ">= 1.0.0"
       }
     },
+    "node_modules/@microsoft/applicationinsights-web-basic/node_modules/@microsoft/applicationinsights-common": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.10.tgz",
+      "integrity": "sha512-RVIenPIvNgZCbjJdALvLM4rNHgAFuHI7faFzHCgnI6S2WCUNGHeXlQTs9EUUrL+n2TPp9/cd0KKMILU5VVyYiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
     "node_modules/@microsoft/dynamicproto-js": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz",
@@ -159,18 +205,18 @@
       }
     },
     "node_modules/@nevware21/ts-async": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.4.tgz",
-      "integrity": "sha512-IBTyj29GwGlxfzXw2NPnzty+w0Adx61Eze1/lknH/XIVdxtF9UnOpk76tnrHXWa6j84a1RR9hsOcHQPFv9qJjA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
+      "integrity": "sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==",
       "license": "MIT",
       "dependencies": {
-        "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
       }
     },
     "node_modules/@nevware21/ts-utils": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.12.5.tgz",
-      "integrity": "sha512-JPQZWPKQJjj7kAftdEZL0XDFfbMgXCGiUAZe0d7EhLC3QlXTlZdSckGqqRIQ2QNl0VTEZyZUvRBw6Ednw089Fw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.13.0.tgz",
+      "integrity": "sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ==",
       "license": "MIT"
     },
     "node_modules/@types/glob": {
@@ -2040,17 +2086,43 @@
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.4 < 2.x",
         "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "dependencies": {
+        "@microsoft/applicationinsights-common": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.10.tgz",
+          "integrity": "sha512-RVIenPIvNgZCbjJdALvLM4rNHgAFuHI7faFzHCgnI6S2WCUNGHeXlQTs9EUUrL+n2TPp9/cd0KKMILU5VVyYiA==",
+          "requires": {
+            "@microsoft/applicationinsights-core-js": "3.3.10",
+            "@microsoft/applicationinsights-shims": "3.0.1",
+            "@microsoft/dynamicproto-js": "^2.0.3",
+            "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+          }
+        }
       }
     },
     "@microsoft/applicationinsights-common": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.10.tgz",
-      "integrity": "sha512-RVIenPIvNgZCbjJdALvLM4rNHgAFuHI7faFzHCgnI6S2WCUNGHeXlQTs9EUUrL+n2TPp9/cd0KKMILU5VVyYiA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
+      "integrity": "sha512-CTbD0g/68tiv2yCItsodDQBYxyHdfQkG7VhvVU8OHenukpl/7W4wEuxZuOntqhv5m9Nx/DFncbz+T83nvYTG3g==",
       "requires": {
-        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+          "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
+          "requires": {
+            "@microsoft/applicationinsights-shims": "3.0.1",
+            "@microsoft/dynamicproto-js": "^2.0.3",
+            "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+            "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+          }
+        }
       }
     },
     "@microsoft/applicationinsights-core-js": {
@@ -2084,6 +2156,19 @@
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.4 < 2.x",
         "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "dependencies": {
+        "@microsoft/applicationinsights-common": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.10.tgz",
+          "integrity": "sha512-RVIenPIvNgZCbjJdALvLM4rNHgAFuHI7faFzHCgnI6S2WCUNGHeXlQTs9EUUrL+n2TPp9/cd0KKMILU5VVyYiA==",
+          "requires": {
+            "@microsoft/applicationinsights-core-js": "3.3.10",
+            "@microsoft/applicationinsights-shims": "3.0.1",
+            "@microsoft/dynamicproto-js": "^2.0.3",
+            "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+          }
+        }
       }
     },
     "@microsoft/dynamicproto-js": {
@@ -2095,17 +2180,17 @@
       }
     },
     "@nevware21/ts-async": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.4.tgz",
-      "integrity": "sha512-IBTyj29GwGlxfzXw2NPnzty+w0Adx61Eze1/lknH/XIVdxtF9UnOpk76tnrHXWa6j84a1RR9hsOcHQPFv9qJjA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
+      "integrity": "sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==",
       "requires": {
-        "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
       }
     },
     "@nevware21/ts-utils": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.12.5.tgz",
-      "integrity": "sha512-JPQZWPKQJjj7kAftdEZL0XDFfbMgXCGiUAZe0d7EhLC3QlXTlZdSckGqqRIQ2QNl0VTEZyZUvRBw6Ednw089Fw=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.13.0.tgz",
+      "integrity": "sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ=="
     },
     "@types/glob": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/Eskibear/vscode-extension-telemetry-wrapper.git"
   },
   "dependencies": {
-    "@microsoft/applicationinsights-common": "npm:@microsoft/applicationinsights-core-js@^3.4.1",
+    "@microsoft/applicationinsights-common": "^3.4.1",
     "@vscode/extension-telemetry": "^1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-extension-telemetry-wrapper",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "A module to auto send telemetry for each registered command in unified format, using @vscode/extension-telemetry.",
   "main": "./lib/src/index.js",
   "activationEvents": [],
@@ -18,6 +18,7 @@
     "url": "https://github.com/Eskibear/vscode-extension-telemetry-wrapper.git"
   },
   "dependencies": {
+    "@microsoft/applicationinsights-common": "^3.4.1",
     "@vscode/extension-telemetry": "^1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/Eskibear/vscode-extension-telemetry-wrapper.git"
   },
   "dependencies": {
-    "@microsoft/applicationinsights-common": "^3.4.1",
+    "@microsoft/applicationinsights-common": "npm:@microsoft/applicationinsights-core-js@^3.4.1",
     "@vscode/extension-telemetry": "^1.2.0"
   },
   "devDependencies": {
@@ -26,10 +26,10 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "^20.8.9",
     "@types/vscode": "1.75.0",
+    "@vscode/test-electron": "^2.4.0",
     "glob": "^7.2.3",
     "mocha": "^9.2.2",
     "tslint": "^5.20.1",
-    "typescript": "^5.3.3",
-    "@vscode/test-electron": "^2.4.0"
+    "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
Bump the package to 0.15.2 and add @microsoft/applicationinsights-common as a runtime dependency so consumers bundling @vscode/extension-telemetry can resolve the Application Insights import.