### PR TITLE
ci: bump to Node 24 and drop npm@latest workaround

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,8 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
-      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm publish --provenance --access public


### PR DESCRIPTION
The release workflow currently works only because of a hidden `npm install -g npm@latest` step that upgrades the bundled npm at runtime. That's fragile:

- It's non-deterministic. Whatever npm is the `latest` tag on release day gets pulled in. If npm regresses OIDC (see [npm/cli#8730](https://github.com/npm/cli/issues/8730) where 11.6.2 broke trusted publishing on Node 24), the workflow silently breaks.
- It hides the real requirement. Trusted publishing with provenance needs npm 11.5.1+. Node 20 ships npm 10.x, which can't do OIDC on its own.

Bumping `setup-node` to Node 24 brings npm 11.x as the bundled version, which supports OIDC trusted publishing out of the box. The in-place upgrade step is no longer needed.

Same fix being applied to `formulahendry/wechat-acp` after we hit this exact issue there.
